### PR TITLE
Add MentalPrep Vite React app skeleton

### DIFF
--- a/mentalprep-app/.eslintrc.json
+++ b/mentalprep-app/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react"],
+  "settings": {
+    "react": {"version": "detect"}
+  },
+  "rules": {}
+}

--- a/mentalprep-app/.prettierrc
+++ b/mentalprep-app/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/mentalprep-app/package.json
+++ b/mentalprep-app/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "mentalprep-app",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint .",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "@stripe/stripe-js": "^1.65.0",
+    "autoprefixer": "^10.4.14",
+    "dayjs": "^1.11.9",
+    "firebase": "^9.22.2",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.5.28",
+    "react": "^18.2.0",
+    "react-calendar": "^3.8.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.6.2",
+    "tailwindcss": "^3.3.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.45.0",
+    "eslint-plugin-react": "^7.32.2",
+    "prettier": "^2.8.8",
+    "postcss": "^8.4.21",
+    "vite": "^4.3.0"
+  }
+}

--- a/mentalprep-app/postcss.config.cjs
+++ b/mentalprep-app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/mentalprep-app/public/index.html
+++ b/mentalprep-app/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MentalPrep</title>
+  </head>
+  <body class="bg-gray-100 dark:bg-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/mentalprep-app/src/App.jsx
+++ b/mentalprep-app/src/App.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from './components/Header.jsx';
+import TeamStatsChart from './components/TeamStatsChart.jsx';
+import HormoneCycle from './components/HormoneCycle.jsx';
+import MentalDiary from './components/MentalDiary.jsx';
+import AiChat from './components/AiChat.jsx';
+import CalendarView from './components/CalendarView.jsx';
+import ProFeatures from './components/ProFeatures.jsx';
+
+export default function App() {
+  return (
+    <div className="py-6 px-4 max-w-3xl mx-auto">
+      <Header />
+      <HormoneCycle />
+      <MentalDiary />
+      <CalendarView />
+      <TeamStatsChart />
+      <AiChat />
+      <ProFeatures />
+    </div>
+  );
+}

--- a/mentalprep-app/src/api/chat.js
+++ b/mentalprep-app/src/api/chat.js
@@ -1,0 +1,9 @@
+export async function sendChatMessage(message) {
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message }),
+  });
+  if (!res.ok) throw new Error('Chat request failed');
+  return res.json();
+}

--- a/mentalprep-app/src/api/create-checkout-session.js
+++ b/mentalprep-app/src/api/create-checkout-session.js
@@ -1,0 +1,8 @@
+export async function createCheckoutSession() {
+  const res = await fetch('/api/create-checkout-session', {
+    method: 'POST',
+  });
+  if (!res.ok) throw new Error('Failed to create checkout session');
+  const { sessionId } = await res.json();
+  return sessionId;
+}

--- a/mentalprep-app/src/api/send-line.js
+++ b/mentalprep-app/src/api/send-line.js
@@ -1,0 +1,11 @@
+export async function sendLineNotify(token, message) {
+  const res = await fetch('https://notify-api.line.me/api/notify', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({ message }),
+  });
+  return res.ok;
+}

--- a/mentalprep-app/src/components/AiChat.jsx
+++ b/mentalprep-app/src/components/AiChat.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { addDoc, collection, Timestamp } from 'firebase/firestore';
+import { db } from '../lib/firebase.js';
+import { sendChatMessage } from '../api/chat.js';
+
+export default function AiChat() {
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input) return;
+    const userMsg = { role: 'user', content: input };
+    setMessages((m) => [...m, userMsg]);
+    setInput('');
+    const res = await sendChatMessage(input);
+    const botMsg = { role: 'assistant', content: res.reply };
+    setMessages((m) => [...m, botMsg]);
+    await addDoc(collection(db, 'userChats'), {
+      messages: [userMsg, botMsg],
+      createdAt: Timestamp.now(),
+    });
+  };
+
+  return (
+    <div className="my-6">
+      <h2 className="text-xl font-semibold mb-2">AI Mental Coach</h2>
+      <div className="border p-2 h-40 overflow-y-auto mb-2 bg-white dark:bg-gray-800">
+        {messages.map((m, i) => (
+          <div key={i} className="mb-1">
+            <strong>{m.role}:</strong> {m.content}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="flex space-x-2">
+        <input
+          className="border flex-1 p-2"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask something..."
+        />
+        <button className="px-4 py-2 bg-green-500 text-white rounded" type="submit">
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/mentalprep-app/src/components/CalendarView.jsx
+++ b/mentalprep-app/src/components/CalendarView.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '../lib/firebase.js';
+import dayjs from 'dayjs';
+
+export default function CalendarView() {
+  const [entries, setEntries] = useState([]);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    const col = collection(db, 'mentalEntries');
+    const unsub = onSnapshot(col, (snap) => {
+      setEntries(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    });
+    return unsub;
+  }, []);
+
+  const tileContent = ({ date }) => {
+    const found = entries.find((e) => dayjs(e.date.toDate()).isSame(date, 'day'));
+    return found ? <span className="text-red-500">●</span> : null;
+  };
+
+  const handleClick = (date) => {
+    const found = entries.find((e) => dayjs(e.date.toDate()).isSame(date, 'day'));
+    setSelected(found || null);
+  };
+
+  return (
+    <div className="my-6">
+      <h2 className="text-xl font-semibold mb-2">Diary Calendar</h2>
+      <Calendar tileContent={tileContent} onClickDay={handleClick} />
+      {selected && (
+        <div className="mt-2 p-2 border bg-white dark:bg-gray-800">
+          <div>Focus: {selected.focus}</div>
+          <div>Anxiety: {selected.anxiety}</div>
+          <div>Mood: {selected.mood}</div>
+          <div>Sleep: {selected.sleep}</div>
+          <div>{selected.comment}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mentalprep-app/src/components/Header.jsx
+++ b/mentalprep-app/src/components/Header.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { signOut, onAuthStateChanged } from '../lib/auth.js';
+
+export default function Header() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(setUser);
+    return unsub;
+  }, []);
+
+  return (
+    <header className="mb-4 flex justify-between items-center">
+      <h1 className="text-2xl font-bold">MentalPrep</h1>
+      {user ? (
+        <div className="flex items-center space-x-2">
+          <span>{user.email}</span>
+          <button
+            onClick={signOut}
+            className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded"
+          >
+            Logout
+          </button>
+        </div>
+      ) : (
+        <span>Not logged in</span>
+      )}
+    </header>
+  );
+}

--- a/mentalprep-app/src/components/HormoneCycle.jsx
+++ b/mentalprep-app/src/components/HormoneCycle.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+
+export default function HormoneCycle() {
+  const [gender, setGender] = useState('male');
+  const [cycle, setCycle] = useState('');
+
+  return (
+    <div className="my-6">
+      <h2 className="text-xl font-semibold mb-2">Hormone Cycle</h2>
+      <div className="space-x-4 mb-2">
+        <label>
+          <input
+            type="radio"
+            value="male"
+            checked={gender === 'male'}
+            onChange={(e) => setGender(e.target.value)}
+          />
+          Male
+        </label>
+        <label>
+          <input
+            type="radio"
+            value="female"
+            checked={gender === 'female'}
+            onChange={(e) => setGender(e.target.value)}
+          />
+          Female
+        </label>
+      </div>
+      {gender === 'female' && (
+        <input
+          type="text"
+          className="border p-2 w-full"
+          placeholder="Enter cycle info"
+          value={cycle}
+          onChange={(e) => setCycle(e.target.value)}
+        />
+      )}
+    </div>
+  );
+}

--- a/mentalprep-app/src/components/MentalDiary.jsx
+++ b/mentalprep-app/src/components/MentalDiary.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { addDoc, collection, Timestamp } from 'firebase/firestore';
+import { db } from '../lib/firebase.js';
+
+export default function MentalDiary() {
+  const [form, setForm] = useState({
+    focus: '',
+    anxiety: '',
+    mood: '',
+    sleep: '',
+    comment: '',
+  });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await addDoc(collection(db, 'mentalEntries'), {
+      ...form,
+      date: Timestamp.now(),
+      satisfaction: Number(form.mood || 0),
+    });
+    setForm({ focus: '', anxiety: '', mood: '', sleep: '', comment: '' });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="my-6 space-y-2">
+      <h2 className="text-xl font-semibold">Mental Diary</h2>
+      {['focus', 'anxiety', 'mood', 'sleep', 'comment'].map((field) => (
+        <input
+          key={field}
+          name={field}
+          value={form[field]}
+          onChange={handleChange}
+          className="border p-2 w-full"
+          placeholder={field}
+        />
+      ))}
+      <button className="px-4 py-2 bg-blue-500 text-white rounded" type="submit">
+        Save
+      </button>
+    </form>
+  );
+}

--- a/mentalprep-app/src/components/ProFeatures.jsx
+++ b/mentalprep-app/src/components/ProFeatures.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { loadStripe } from '@stripe/stripe-js';
+import { createCheckoutSession } from '../api/create-checkout-session.js';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+const stripePromise = loadStripe('YOUR_STRIPE_PUBLISHABLE_KEY');
+
+export default function ProFeatures() {
+  const handleCheckout = async () => {
+    const sessionId = await createCheckoutSession();
+    const stripe = await stripePromise;
+    await stripe.redirectToCheckout({ sessionId });
+  };
+
+  const handleExport = () => {
+    const doc = new jsPDF();
+    autoTable(doc, {
+      head: [['Metric', 'Value']],
+      body: [
+        ['Focus', ''],
+        ['Anxiety', ''],
+        ['Mood', ''],
+        ['Sleep', ''],
+      ],
+    });
+    doc.save('report.pdf');
+  };
+
+  return (
+    <div className="my-6">
+      <h2 className="text-xl font-semibold mb-2">Pro Features</h2>
+      <button
+        onClick={handleCheckout}
+        className="px-4 py-2 bg-purple-500 text-white rounded mr-2"
+      >
+        Subscribe (¥500/mo)
+      </button>
+      <button
+        onClick={handleExport}
+        className="px-4 py-2 bg-gray-500 text-white rounded"
+      >
+        Export PDF
+      </button>
+    </div>
+  );
+}

--- a/mentalprep-app/src/components/TeamStatsChart.jsx
+++ b/mentalprep-app/src/components/TeamStatsChart.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from '../lib/firebase.js';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import dayjs from 'dayjs';
+
+export default function TeamStatsChart() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const col = collection(db, 'mentalEntries');
+    const unsub = onSnapshot(col, (snap) => {
+      const grouped = {};
+      snap.docs.forEach((doc) => {
+        const d = doc.data();
+        const date = dayjs(d.date).format('YYYY-MM-DD');
+        if (!grouped[date]) grouped[date] = [];
+        grouped[date].push(d.satisfaction);
+      });
+      const res = Object.entries(grouped).map(([date, arr]) => ({
+        date,
+        satisfaction: arr.reduce((a, b) => a + b, 0) / arr.length,
+      }));
+      setData(res);
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <div className="my-6">
+      <h2 className="text-xl font-semibold mb-2">Team Satisfaction</h2>
+      <LineChart width={500} height={300} data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="date" />
+        <YAxis domain={[0, 5]} />
+        <Tooltip />
+        <Line type="monotone" dataKey="satisfaction" stroke="#8884d8" />
+      </LineChart>
+    </div>
+  );
+}

--- a/mentalprep-app/src/index.css
+++ b/mentalprep-app/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/mentalprep-app/src/lib/auth.js
+++ b/mentalprep-app/src/lib/auth.js
@@ -1,0 +1,18 @@
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut as firebaseSignOut, onAuthStateChanged as firebaseOnAuthStateChanged } from 'firebase/auth';
+import { auth } from './firebase.js';
+
+export function signUp(email, password) {
+  return createUserWithEmailAndPassword(auth, email, password);
+}
+
+export function signIn(email, password) {
+  return signInWithEmailAndPassword(auth, email, password);
+}
+
+export function signOut() {
+  return firebaseSignOut(auth);
+}
+
+export function onAuthStateChanged(callback) {
+  return firebaseOnAuthStateChanged(auth, callback);
+}

--- a/mentalprep-app/src/lib/firebase.js
+++ b/mentalprep-app/src/lib/firebase.js
@@ -1,0 +1,17 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);
+export const auth = getAuth(app);
+export default app;

--- a/mentalprep-app/src/main.jsx
+++ b/mentalprep-app/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/mentalprep-app/tailwind.config.cjs
+++ b/mentalprep-app/tailwind.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/mentalprep-app/vite.config.js
+++ b/mentalprep-app/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize MentalPrep app using Vite + React
- add Tailwind and PostCSS config
- add Firebase auth utilities
- implement basic components and API helpers
- configure ESLint and Prettier

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844fe0a7eec8328a081917c6e709d91